### PR TITLE
Fixed issue #29

### DIFF
--- a/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
+++ b/lightcrafts/src/com/lightcrafts/model/ImageEditor/Rendering.java
@@ -327,8 +327,8 @@ public class Rendering implements Cloneable {
 
         // Scale
         if (scaleFactor < 1 || !isInputTransform) {
-            float scaleX = (float) Math.floor(scaleFactor * sourceBounds.width) / (float) sourceBounds.width;
-            float scaleY = (float) Math.floor(scaleFactor * sourceBounds.height) / (float) sourceBounds.height;
+            float scaleX = (float) Math.round(scaleFactor * sourceBounds.width) / (float) sourceBounds.width;
+            float scaleY = (float) Math.round(scaleFactor * sourceBounds.height) / (float) sourceBounds.height;
             transform.preConcatenate(AffineTransform.getScaleInstance(scaleX, scaleY));
         }
 


### PR DESCRIPTION
Currently, we use Math.round() in ExportSizeFields.java to calculate resized image size, but in Rendering.java:330 we use Math.floor(). To fix the isuue #29, Math.round() should be used in both place.

Note that if we use Math.floor() in both place, we can't fix the issue, because we use Math.min() to set the scale factor in ImageEditorEngine.java:719.
