### PR TITLE
Add commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,6 @@
 # Fix typos
+587c4967143d29c66fd4e242d2ec5fb04bae22c7
+# Fix typos
 4b494d82fb251abf19d2e8edeadf505c8dd8dad6
 # Fix whitespace anomalies
 ac40a415d11e30e38cdfba2ba430c84831fff064


### PR DESCRIPTION
Add a previous typo commit (587c4967143d29c66fd4e242d2ec5fb04bae22c7) to .git-blame-ignore-revs