### PR TITLE
Fix various typos

### DIFF
--- a/lightcrafts/jnisrc/EDISON/segm/ms.cpp
+++ b/lightcrafts/jnisrc/EDISON/segm/ms.cpp
@@ -323,7 +323,7 @@ void MeanShift::AddWeightFunction(double g(double), float halfWindow, int sample
 /*private data structure.                              */
 /*******************************************************/
 /*Post:                                                */
-/*      - all user defined weight functions ahve been  */
+/*      - all user defined weight functions have been  */
 /*        cleared from the private data structure of   */
 /*        the mean shift class.                        */
 /*******************************************************/

--- a/lightcrafts/jnisrc/EDISON/segm/ms.h
+++ b/lightcrafts/jnisrc/EDISON/segm/ms.h
@@ -104,7 +104,7 @@ struct ClassStateStruct {
 
  // Threshold
 const double   EPSILON        = 0.01;  // define threshold (approx. Value of Mh at a peak or plateau)
-const double   MU             = 0.05;	// define threshold required that window is near convergence
+const double   MU             = 0.05;  // define threshold required that window is near convergence
 const double   TC_DIST_FACTOR	= 0.5;   // cluster search windows near convergence that are a distance
                                        // h[i]*TC_DIST_FACTOR of one another (transitive closure)
 const double   SQ_TC_DFACTOR  = 0.0625; // (TC_DIST_FACTOR)^2
@@ -117,7 +117,7 @@ const double   GAUSS_INCREMENT = GAUSS_LIMIT*GAUSS_LIMIT/GAUSS_NUM_ELS;
                                        // GAUSS_INCREMENT = (c^2)/(# of samples)
 
  // Numerical Analysis
-const double   DELTA           = 0.00001;	// used for floating point to integer conversion
+const double   DELTA           = 0.00001; // used for floating point to integer conversion
 
 //MeanShift Prototype
 class MeanShift {
@@ -639,7 +639,7 @@ class MeanShift {
   //|   library class method or because of insufficient  |//
   //|   resources. ErrorStatus is set to EL_ERROR        |//
   //|   (ErrorStatus = 1) if an error has occurred. If   |//
-  //|   no error occured when calling a particular       |//
+  //|   no error occurred when calling a particular      |//
   //|   method ErrorStatus is set to EL_OKAY             |//
   //|   (ErrorStatus = 0).                               |//
   //|                                                    |//
@@ -703,8 +703,8 @@ class MeanShift {
 
    /////////////////////////////////////////////////////
    // <<*>> Usage: ErrorHandler(                <<*>> //
-   //       className, functName, errMessage)         //      
-   /////////////////////////////////////////////////////                           
+   //       className, functName, errMessage)         //
+   /////////////////////////////////////////////////////
 
    void ErrorHandler(const char*, const char*, const char*);		// flags an error and halts the system
 
@@ -717,21 +717,21 @@ class MeanShift {
    //#########   MEAN SHIFT SYSTEM   ##########
    //##########################################
 
-	msSystem    msSys;                     // used for function timing and system output
+   msSystem    msSys;                     // used for function timing and system output
 
    //##########################################
    //######### INPUT DATA PARAMETERS ##########
    //##########################################
 
-	int         L, N, kp, *P;              // length, dimension, subspace number, and subspace dimensions
+   int         L, N, kp, *P;              // length, dimension, subspace number, and subspace dimensions
 
 
    //##########################################
    //######### INPUT DATA STORAGE    ##########
    //##########################################
 
-	////////Linear Storage (used by lattice and bst)////////
-	float       *data;                     // memory allocated for data points stored by tree nodes
+   ////////Linear Storage (used by lattice and bst)////////
+   float       *data;                     // memory allocated for data points stored by tree nodes
                                           // when used by the lattice data structure data does not store
                                           // the lattice information; format of data:
                                           // data = <x11, x12, ..., x1N,...,xL1, xL2, ..., xLN>
@@ -741,23 +741,23 @@ class MeanShift {
    //######## LATTICE DATA STRUCTURE ##########
    //##########################################
 
-	////////Lattice Data Structure////////
-	int         height, width;             // Height and width of lattice
+   ////////Lattice Data Structure////////
+   int         height, width;             // Height and width of lattice
 
    //##########################################
    //######### KERNEL DATA STRUCTURE ##########
    //##########################################
 
-	float       *h;                        // bandwidth vector
+   float       *h;                        // bandwidth vector
 
-	float       *offset;                   // defines bandwidth offset caused by the use of a Gaussian kernel
+   float       *offset;                   // defines bandwidth offset caused by the use of a Gaussian kernel
                                           // (for example)
 
    //##########################################
    //#########  BASIN OF ATTRACTION  ##########
    //##########################################
 
-	unsigned char  *modeTable;             // Assigns a marking to each data point specifying whether
+   unsigned char  *modeTable;             // Assigns a marking to each data point specifying whether
                                           // or not it has been assigned a mode. These labels are:
                                           // modeTable[i] = 0 - data point i is not associated with a mode
                                           // modeTable[i] = 1 - data point i is associated with a mode
@@ -768,7 +768,7 @@ class MeanShift {
                                           // converge to the same mode as the mode that mean shift is
                                           // currently being applied to
 
-	int         pointCount;                // the number of points stored by the point list
+   int         pointCount;                // the number of points stored by the point list
 
 
    //##########################################
@@ -796,18 +796,18 @@ class MeanShift {
   // *** Private Methods ***
   //========================
 
-	 /*/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\*/
-	 /* Kernel Creation/Manipulation */
-	 /*\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/*/
+    /*/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\*/
+    /* Kernel Creation/Manipulation */
+    /*\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/*/
 
    void  generateLookupTable ( void );    // Generates Weight Function Lookup Table
 
    void  DestroyKernel       ( void );    // Destroys mean shift kernel, re-initializes kernel
 
 
-	 /*/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\*/
-	 /* Input Data Initialization/Destruction  */
-	 /*\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/*/
+    /*/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\*/
+    /* Input Data Initialization/Destruction  */
+    /*\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/*/
 
    void  CreateBST           ( void );    // Upload input into a kd-BST
 
@@ -892,7 +892,7 @@ class MeanShift {
    //######### INPUT DATA STORAGE    ##########
    //##########################################
 
-	////////Range Searching on General Input Data Set////////
+   ////////Range Searching on General Input Data Set////////
    tree        *root;                     // root of kdBST used to store input
 
    tree        *forest;                   // memory allocated for tree nodes
@@ -915,8 +915,8 @@ class MeanShift {
    //######### LATTICE DATA STRUCTURE #########
    //##########################################
 
-	////////Lattice Data Structure////////
-	int         LowerBoundX, UpperBoundX;  // Upper and lower bounds for lattice search window
+   ////////Lattice Data Structure////////
+   int         LowerBoundX, UpperBoundX;  // Upper and lower bounds for lattice search window
                                           // in the x dimension
 
    int         LowerBoundY, UpperBoundY;  // Upper and lower bounds for lattice search window

--- a/lightcrafts/jnisrc/EDISON/segm/msSys.h
+++ b/lightcrafts/jnisrc/EDISON/segm/msSys.h
@@ -178,8 +178,8 @@ class msSystem {
   //|   This method is called by the mean shift library  |//
   //|   methods during the application of a specific     |//
   //|   algorithm in which the progress of the algorithm |//
-  //|   is indicated. Its main use is for a multi-thre-  |//
-  //|   aded programming environment. Namely, it is      |//
+  //|   is indicated. Its main use is for a multi-       |//
+  //|   threaded programming environment. Namely, it is  |//
   //|   called fairly frequently by the mean shift       |//
   //|   library methods. It then can be used to grace-   |//
   //|   fully halt the algorithm, or to simply update    |//

--- a/lightcrafts/src/main/java/com/lightcrafts/app/CheckForUpdate.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/app/CheckForUpdate.java
@@ -504,7 +504,7 @@ public final class CheckForUpdate {
     private static final String CHECK_FOR_UPDATE_KEY = "CheckForUpdate";
 
     /**
-     * Ths fully qualified host name of that we need to check with to see if
+     * The fully qualified host name of that we need to check with to see if
      * there's a new version.
      * @see #CHECK_URI_STRING
      */

--- a/lightcrafts/src/main/java/com/lightcrafts/image/types/CIFFConstants.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/image/types/CIFFConstants.java
@@ -70,13 +70,13 @@ public interface CIFFConstants {
     int CIFF_DATA_LOC_IN_ENTRY = 0x4000;
 
     /**
-     * Ths size (in bytes) of a CIFF unsigned long.
+     * The size (in bytes) of a CIFF unsigned long.
      * Note that this is not the same size as a Java <code>long</code>.
      */
     int CIFF_FIELD_SIZE_ULONG    = 4;
 
     /**
-     * Ths size (in bytes) of a CIFF unsigned short.
+     * The size (in bytes) of a CIFF unsigned short.
      */
     int CIFF_FIELD_SIZE_USHORT   = 2;
 

--- a/lightcrafts/src/main/java/com/lightcrafts/image/types/JPEGImageType.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/image/types/JPEGImageType.java
@@ -307,7 +307,7 @@ public class JPEGImageType extends ImageType implements TrueImageTypeProvider {
      * Gets a JPEG image from the file given by {@link ImageInfo#getFile()}.
      *
      * @param imageInfo The {@link ImageInfo} to get the actual image from.
-     * @param thread The thread that will do othe getting.
+     * @param thread The thread that will do other getting.
      * @param maxWidth The maximum width of the image to get, rescaling if
      * necessary.  A value of 0 means don't scale.
      * @param maxHeight The maximum height of the image to get, rescaling if

--- a/lightcrafts/src/main/java/com/lightcrafts/jai/opimage/BlendOpImage.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/jai/opimage/BlendOpImage.java
@@ -199,7 +199,7 @@ public class BlendOpImage extends PointOpImage {
             if (!mask.intersects(destRect)) {
                 if (opacity > 0)
                     return this.getSourceImage(1).getTile(tileX, tileY);
-                // Not a good idea, can come out with teh wrong number of bands
+                // Not a good idea, can come out with the wrong number of bands
                 /* else if (opacity == -1)
                     return this.getSourceImage(0).getTile(tileX, tileY); */
             }
@@ -258,7 +258,7 @@ public class BlendOpImage extends PointOpImage {
 
                     return;
                 }
-                // Not a good idea, can come out with teh wrong number of bands
+                // Not a good idea, can come out with the wrong number of bands
                 /* else if (opacity == -1) {
                     assert dest.getBounds().equals(sources[0].getBounds());
 

--- a/lightcrafts/src/main/java/com/lightcrafts/jai/utils/LCTileScheduler.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/jai/utils/LCTileScheduler.java
@@ -1003,7 +1003,7 @@ public final class LCTileScheduler implements TileScheduler {
     }
 
     /**
-     * Prefetchs a list of tiles of an image.
+     * Prefetches a list of tiles of an image.
      *
      * @param owner  The image the tiles belong to.
      * @param tileIndices  An array of tile X and Y indices.

--- a/lightcrafts/src/main/java/com/lightcrafts/platform/DefaultPrinterLayer.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/platform/DefaultPrinterLayer.java
@@ -121,7 +121,7 @@ public class DefaultPrinterLayer implements PrinterLayer {
             printCancelled = false;
 
             /**
-             * NOTE: Mac OS X has a bug in the landscape printing, this hack rotates te image and prints portrait anyway
+             * NOTE: MacOS X has a bug in the landscape printing, this hack rotates the image and prints portrait anyway
              */
             int orientation = format.getOrientation();
             if (orientation != PageFormat.PORTRAIT && Platform.isMac())

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/browser/model/PreviewUpdater.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/browser/model/PreviewUpdater.java
@@ -204,7 +204,7 @@ public class PreviewUpdater extends Thread {
     }
 
     /**
-     * Report our File, as defined in ths PreviewUpdater's ImageMetadata.
+     * Report our File, as defined in the PreviewUpdater's ImageMetadata.
      * This is useful in the application logic for deciding what to do when
      * someone clicks on a preview image.
      */

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/browser/view/BrowserScrollPaneUI.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/browser/view/BrowserScrollPaneUI.java
@@ -14,7 +14,7 @@ import java.awt.event.MouseWheelListener;
  * physical wheel click to translate into one scroll unit increment, which
  * the browser interprets as one row of browser thumbnails.
  * <p>
- * On Mac, BasicScrollPaneUI sems to possess this virtue for free.
+ * On Mac, BasicScrollPaneUI seems to possess this virtue for free.
  */
 
 class BrowserScrollPaneUI extends BasicScrollPaneUI {

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/crop/NumberTextField.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/crop/NumberTextField.java
@@ -92,7 +92,7 @@ public class NumberTextField extends JTextField implements DocumentListener {
     }
 
     /**
-     * Get the number value fo the current text, or throw IllegalStateException
+     * Get the number value of the current text, or throw IllegalStateException
      * if the current text is not a verifiable number.
      */
     public int getNumber() {

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/editor/assoc/DefaultDocuments.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/editor/assoc/DefaultDocuments.java
@@ -50,7 +50,7 @@ class DefaultDocuments {
 
     /**
      * Tell if the given ImageMetadata points to a File containing RAW
-     * image data.  Only RAW files cna have default Documents.
+     * image data.  Only RAW files can have default Documents.
      */
     private static boolean isRaw(ImageMetadata meta) {
         ImageType type = meta.getImageType();

--- a/lightcrafts/src/main/java/com/lightcrafts/utils/bytebuffer/LCByteBuffer.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/utils/bytebuffer/LCByteBuffer.java
@@ -500,7 +500,7 @@ public abstract class LCByteBuffer {
     }
 
     /**
-     * Gets ths buffer's initial offset.
+     * Gets the buffer's initial offset.
      *
      * @return Returns said offset.
      * @see #initialOffset(int)
@@ -605,7 +605,7 @@ public abstract class LCByteBuffer {
         //
         // We use a heuristic of extracting a short both using big and little
         // endian byte orders.  The assumption is that reading the bytes in the
-        // right order willl yield a smaller number than the wrong order, e.g.
+        // right order will yield a smaller number than the wrong order, e.g.
         // 0x0100 is 1 when read as little endian is 1 but is 256 when read as
         // big endian.
         //

--- a/macosx/BUILD-macosx.md
+++ b/macosx/BUILD-macosx.md
@@ -29,7 +29,7 @@ You need to install following packages using homebrew:
 - __lensfun__
 - __libomp__
 - __libraw__
-- __libtiff__ "brew edit libtiff", replace all "jpeg" occurences with "jpeg-turbo", then "brew install libtiff --build-from-source"
+- __libtiff__ "brew edit libtiff", replace all "jpeg" occurrences with "jpeg-turbo", then "brew install libtiff --build-from-source"
 - __little-cms2__
 - __pkg-config__
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "./lightcrafts/locale,./lightcrafts/help,./lightcrafts/src/main/locale,./linux/src/main/locale,./macosx/src/main/locale" -L abd,bu,indeces,ist,laf,makro,ois,optio,padd`