### PR TITLE
refactor: Use java.util.concurrent.ScheduledExecutorService as debounce timer

### DIFF
--- a/lightcrafts/src/main/java/com/lightcrafts/model/ImageEditor/ZoneFinder.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/model/ImageEditor/ZoneFinder.java
@@ -20,7 +20,6 @@ import javax.media.jai.LookupTableJAI;
 import javax.media.jai.PlanarImage;
 import javax.media.jai.RenderedOp;
 import javax.swing.SwingUtilities;
-import javax.swing.Timer;
 import java.awt.*;
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_ColorSpace;
@@ -429,10 +428,11 @@ public class ZoneFinder extends Preview implements PaintListener {
         }
 
         try {
-            scheduler.shutdownNow();
-            scheduler.awaitTermination(200, TimeUnit.MILLISECONDS);
+            if (! scheduler.awaitTermination(200, TimeUnit.MILLISECONDS)) {
+                scheduler.shutdownNow();
+            }
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            scheduler.shutdownNow();
         }
     }
 

--- a/lightcrafts/src/main/java/com/lightcrafts/model/ImageEditor/ZoneFinder.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/model/ImageEditor/ZoneFinder.java
@@ -52,7 +52,7 @@ public class ZoneFinder extends Preview implements PaintListener {
 
     // Scheduled executor for debounced segmentation tasks
     @NotNull
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> debounceFuture = null;
 
     @Override
@@ -475,6 +475,10 @@ public class ZoneFinder extends Preview implements PaintListener {
             // cancel any pending scheduled task and reschedule
             if (debounceFuture != null) {
                 debounceFuture.cancel(false);
+            }
+
+            if (scheduler.isShutdown()) {
+                scheduler = Executors.newSingleThreadScheduledExecutor();
             }
 
             // Debounce via ScheduledExecutorService


### PR DESCRIPTION
Using a framework for thread creation and management makes parallel execution clear and easier to manage.

See #367 and https://github.com/ktgw0316/LightZone/pull/368#discussion_r2448286084.

@cycomanic Could you confirm that this change does not cause performance degradation? There was no change at least in my environment, but I want to make it sure.