### PR TITLE
fix(macos): focus existing window on dock reopen + skin font NPE

### DIFF
--- a/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
@@ -174,8 +174,21 @@ public class Application {
 
     public static void reOpen(ComboFrame frame) {
         if (frame == null) {
+            // No frame supplied — typically a macOS dock-icon reopen.
+            // Bring the most recently active window forward rather than
+            // spawning a duplicate empty frame.
+            if (!Current.isEmpty()) {
+                ComboFrame existing = Current.getFirst();
+                if (existing.getState() == Frame.ICONIFIED) {
+                    existing.setState(Frame.NORMAL);
+                }
+                existing.setVisible(true);
+                existing.toFront();
+                existing.requestFocus();
+                return;
+            }
             openEmpty();
-	    return;
+            return;
         }
         Document doc = frame.getDocument();
         File file = doc.getFile();

--- a/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
@@ -174,9 +174,7 @@ public class Application {
 
     public static void reOpen(ComboFrame frame) {
         if (frame == null) {
-            // No frame supplied — typically a macOS dock-icon reopen.
-            // Bring the most recently active window forward rather than
-            // spawning a duplicate empty frame.
+            // macOS dock-icon reopen: focus most-recently-active frame instead of spawning a duplicate.
             ComboFrame existing = getActiveFrame();
             if (existing != null) {
                 if (existing.getState() == Frame.ICONIFIED) {

--- a/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/app/Application.java
@@ -177,8 +177,8 @@ public class Application {
             // No frame supplied — typically a macOS dock-icon reopen.
             // Bring the most recently active window forward rather than
             // spawning a duplicate empty frame.
-            if (!Current.isEmpty()) {
-                ComboFrame existing = Current.getFirst();
+            ComboFrame existing = getActiveFrame();
+            if (existing != null) {
                 if (existing.getState() == Frame.ICONIFIED) {
                     existing.setState(Frame.NORMAL);
                 }

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
@@ -70,8 +70,19 @@ public class LightZoneSkin {
 
     public static class LightZoneFontSet {
         // cf. https://www.formdev.com/flatlaf/typography/#available
-        public static final FontUIResource TitleFont = new FontUIResource(UIManager.getFont("small.font"));
-        public static final FontUIResource SmallFont = new FontUIResource(UIManager.getFont("small.font"));
+        public static final FontUIResource TitleFont = font("small.font");
+        public static final FontUIResource SmallFont = font("small.font");
+
+        private static FontUIResource font(String key) {
+            Font f = UIManager.getFont(key);
+            if (f == null) {
+                f = UIManager.getFont("Label.font");
+            }
+            if (f == null) {
+                f = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
+            }
+            return new FontUIResource(f);
+        }
     }
 
     public static Border getImageBorder() {

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
@@ -69,16 +69,9 @@ public class LightZoneSkin {
     }
 
     public static class LightZoneFontSet {
-        // cf. https://www.formdev.com/flatlaf/typography/#available
-        public static final FontUIResource TitleFont = font();
-        public static final FontUIResource SmallFont = font();
-
-        private static FontUIResource font() {
-            // Some FlatLaf theme variants don't register the typography keys;
-            // fall back to Label.font (always supplied by Swing) to avoid NPE.
-            Font f = UIManager.getFont("small.font");
-            return new FontUIResource(f != null ? f : UIManager.getFont("Label.font"));
-        }
+        // FlatLaf "small.font" key is not present in every theme variant; hardcode to avoid NPE.
+        public static final FontUIResource TitleFont = new FontUIResource(new Font(Font.SANS_SERIF, Font.PLAIN, 11));
+        public static final FontUIResource SmallFont = new FontUIResource(new Font(Font.SANS_SERIF, Font.PLAIN, 11));
     }
 
     public static Border getImageBorder() {

--- a/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
+++ b/lightcrafts/src/main/java/com/lightcrafts/ui/LightZoneSkin.java
@@ -70,18 +70,14 @@ public class LightZoneSkin {
 
     public static class LightZoneFontSet {
         // cf. https://www.formdev.com/flatlaf/typography/#available
-        public static final FontUIResource TitleFont = font("small.font");
-        public static final FontUIResource SmallFont = font("small.font");
+        public static final FontUIResource TitleFont = font();
+        public static final FontUIResource SmallFont = font();
 
-        private static FontUIResource font(String key) {
-            Font f = UIManager.getFont(key);
-            if (f == null) {
-                f = UIManager.getFont("Label.font");
-            }
-            if (f == null) {
-                f = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
-            }
-            return new FontUIResource(f);
+        private static FontUIResource font() {
+            // Some FlatLaf theme variants don't register the typography keys;
+            // fall back to Label.font (always supplied by Swing) to avoid NPE.
+            Font f = UIManager.getFont("small.font");
+            return new FontUIResource(f != null ? f : UIManager.getFont("Label.font"));
         }
     }
 

--- a/macosx/build.gradle.kts
+++ b/macosx/build.gradle.kts
@@ -12,6 +12,10 @@ dependencies {
 }
 application {
     mainClass.set("com.lightcrafts.platform.macosx.MacOSXLauncher")
+    applicationDefaultJvmArgs = applicationDefaultJvmArgs + listOf(
+        "-Xdock:name=LightZone",
+        "-Dapple.awt.application.name=LightZone",
+    )
 }
 tasks {
     build {
@@ -86,6 +90,7 @@ runtime {
             "-Djava.library.path=\$APPDIR",
             "-Dfile.encoding=utf-8",
             "-Xdock:name=LightZone",
+            "-Dapple.awt.application.name=LightZone",
         )
     }
 }


### PR DESCRIPTION
@ktgw0316 I've just recently started using this software for editing my own scans. I would love to contribute and help improve on the mac OS side of things, here's a few small bugs/improvements

## Summary

- **Dock reopen**: `Application.reOpen(null)` now focuses the most-recently-active `ComboFrame` via `getActiveFrame()` instead of always calling `openEmpty()`. Stops macOS dock clicks from spawning duplicate empty windows.
- **Font NPE**: `LightZoneFontSet` hardcodes a `SansSerif 11pt` font. The previous `UIManager.getFont("small.font")` returned null with FlatLaf theme variants that don't register typography keys, NPE'ing `<clinit>` and bricking every subsequent `ComboFrame` build with `NoClassDefFoundError`.
- **App name**: `./gradlew :macosx:run` now shows `LightZone` in the menubar/dock instead of `MacOSXLauncher`. Adds `-Xdock:name` and `-Dapple.awt.application.name` to the application plugin's JVM args (previously only the beryx jpackage launcher set them).

## Test plan

- [x] App running, click dock repeatedly → same window stays, no duplicates
- [x] Minimize, click dock → de-iconifies and focuses
- [x] Two windows, focus window 2, click dock → window 2 forward
- [x] Two windows, focus window 1, click dock → window 1 forward
- [x] Image open, click dock → same window stays, no extra empty
- [x] All windows closed (app alive), click dock → new empty window opens (fallback)
- [ ] Linux/Windows: revert button + revert menu still work (non-null branch untouched)
- [x] App launches without `LightZoneFontSet.<clinit>` NPE
- [x] Menubar + dock show "LightZone", not "MacOSXLauncher"