### PR TITLE
Add seo config for autogenerated gh pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+title: LightZone
+description: >-
+  Free, open-source professional RAW photo editor for macOS, Windows, and Linux.
+  Features non-destructive editing, Zone System tools, batch processing, and
+  16-bit linear ProPhoto RGB color space.
+url: https://ktgw0316.github.io
+baseurl: /LightZone
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap


### PR DESCRIPTION
closes #377 

note for @ktgw0316 from the issue body:
```

2. Delete stale gh-pages branch

The gh-pages branch still exists with the default auto-generator template from years ago. Its index.html references the old AntonKast fork in the page title and download buttons:

    <title>Lightzone by AntonKast</title>
    Download buttons link to https://github.com/AntonKast/LightZone/zipball/master

The branch is not served (Pages config renders from master) but it is discoverable via the branch list and via Google's cache, and it points users to a different maintainer's fork. Safe to delete.
```
